### PR TITLE
Upd c08a6fa EOL gyao.yahoo.co.jp

### DIFF
--- a/SpywareFilter/sections/allowlist.txt
+++ b/SpywareFilter/sections/allowlist.txt
@@ -1188,8 +1188,6 @@ ntp.msn.com#@%#navigator.getBattery = undefined;
 ! https://github.com/AdguardTeam/AdguardFilters/issues/91087
 !+ NOT_PLATFORM(windows, mac, android, ext_chromium)
 @@||googletagmanager.com/gtm.js$domain=shockwave.com
-! fix history on Firefox
-@@||dsb.yahoo.co.jp/api/v1/stream$xmlhttprequest,domain=gyao.yahoo.co.jp
 ! https://github.com/AdguardTeam/AdguardFilters/issues/90683
 @@||googletagmanager.com/gtag/js?id=$domain=rotana.net
 ||googletagmanager.com/gtag/js?id=$script,other,redirect=noopjs,domain=rotana.net,important


### PR DESCRIPTION
## Prerequisites

### To avoid invalid pull requests, please check and confirm following terms

- [x] This is not an ad/bug report;
- [x] My code follows the [guidelines](https://github.com/AdguardTeam/AdguardFilters/blob/master/CONTRIBUTING.md) and [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) of this project;
- [x] I have performed a self-review of my own changes;
- [x] My changes do not break web sites, apps and files structure.

## What problem does the pull request fix?

### If the problem does not fall under any category that is listed here, please write a comment below in corresponding section

- [ ] Missed ads or ad leftovers;
- [ ] Website or app doesn't work properly;
- [ ] AdGuard gets detected on a website;
- [ ] Missed analytics or tracker;
- [ ] Social media buttons — share, like, tweet, etc;
- [ ] Annoyances — pop-ups, cookie warnings, etc;
- [x] Filters maintenance.

## What issue is being fixed?

### Enter the issue address

\-

### Add your comment and screenshots

gyao.yahoo.co.jp has ended its service.
Addition of c08a6fa3d059f534422aa209169edb73aeecdb2e

### Terms

- [x] By submitting this issue, I agree that pull request does not contain private info and all conditions are met
